### PR TITLE
feat: add components docs

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -12,7 +12,7 @@ The source code is available here [host-operator](https://github.com/codeready-t
 ## Member Operator
 The member operator is _KubeSaw's data-plane_, which is responsible for provisioning and managing the user namespaces and all the configurations inside those namespaces.
 
-There can be multiple member operators deployed as part of the same KubeSaw instance, ideally there should be a member operator per each cluster dedicated to the user workload (member cluster).
+There can be multiple member operators deployed as part of the same KubeSaw instance, ideally there should be one member operator per each cluster, dedicated to the user workload (member cluster).
 
 The source code is available here [member-operator](https://github.com/codeready-toolchain/member-operator)
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -31,7 +31,7 @@ the proxy infers the target cluster from the user information and the target wor
 
 Both Proxy and Registration-service are optional components and not required for having a fully functional KubeSaw instance.
 The registration service can be useful if your KubeSaw service requires a signup mechanism/frontend.
-The proxy can help, in the case of a multi-cluster solution, with removing some of the _cluster awareness_ and friction for the end users or clients interacting with the member clusters.
+The proxy can help, in the case of a multi-cluster solution, with removing some of the _cluster awareness_ and friction for the end users or clients interacting with the member clusters. Another key feature of the proxy is that it accepts SSO tokens, not kube tokens. This keeps authorization and authentication centralized, which can be managed from the identity provider (atm only Keycloak is supported).
 
 The source code for both registration-service and proxy is available here [registration-service](https://github.com/codeready-toolchain/registration-service)
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -2,7 +2,7 @@
 This page provides a brief description of each KubeSaw component.
 
 ## Host Operator
-The host-operator is _KubeSaw's control-plane_, is responsible for managing the users, spaces, notification and monitoring the kubesaw instance.
+The host-operator is _KubeSaw's control-plane_, is responsible for managing the users, spaces, notifications and monitoring the kubesaw instance.
 One of the resources managed by host operator is the UserSignup resource, which is the source of truth for all user accounts. All other user-related resources are created from the UserSignup.
 
 At the moment, there can be only one host operator deployed per KubeSaw instance.
@@ -12,20 +12,26 @@ The source code is available here [host-operator](https://github.com/codeready-t
 ## Member Operator
 The member operator is _KubeSaw's data-plane_, is responsible for provisioning and managing the user namespaces and all the configuration inside those namespaces.
 
-There can be multiple member-operator deployed per KubeSaw instance, ideally there would be a member operator per each member cluster.
+There can be multiple member operators deployed as part of the same KubeSaw instance, ideally there should be a member operator per each cluster dedicated to the user workload (member cluster).
 
 The source code is available here [member-operator](https://github.com/codeready-toolchain/member-operator)
 
 ## Registration Service
-The Registration Service is a standalone web application that runs on the host cluster.  It provides a number of REST endpoints that the signup page can use to allow a user to sign up for a KubeSaw account. 
-The Registration Service application makes use of third party libraries such as Gin (an HTTP web framework) and Kubernetes client libraries (for interacting with the Kubernetes API) among others.
+The Registration Service is a standalone web application that runs on the same cluster as the host operator
+(host cluster).
+It provides a number of REST endpoints that the signup page can use to allow a user to sign up for a KubeSaw account. 
+The Registration Service application makes use of third party libraries such as Gin (an HTTP web framework)
+and Kubernetes client libraries (for interacting with the Kubernetes API) among others.
 
 ### Proxy
-The Proxy is part of the registration-service application deployment, basically it's another set of REST endpoints implemented using the echo framework. It can be used in a multi-cluster environment to forward requests without the need to specify the cluster name, the proxy infers the target cluster from the user information and the target workspace/namespace of the request.
+The Proxy is part of the registration service application deployment,
+basically it's another set of REST endpoints implemented using the echo framework.
+It can be used in a multi-cluster environment to forward requests without the need to specify the cluster context,
+the proxy infers the target cluster from the user information and the target workspace/namespace of the request.
 
 Both Proxy and Registration-service are optional components and not required for having a fully functional KubeSaw instance.
-The registration service can be useful if your KubeSaw instance needs a signup mechanism/frontend.
-The proxy can help in the case of a multi-cluster solution with removing some of the _cluster awareness_ and friction for the end users or clients interacting with the instance.
+The registration service can be useful if your KubeSaw service requires a signup mechanism/frontend.
+The proxy can help, in the case of a multi-cluster solution, with removing some of the _cluster awareness_ and friction for the end users or clients interacting with the member clusters.
 
 The source code for both registration-service and proxy is available here [registration-service](https://github.com/codeready-toolchain/registration-service)
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -10,7 +10,7 @@ At the moment, only one host operator can be deployed per KubeSaw instance.
 The source code is available here [host-operator](https://github.com/codeready-toolchain/host-operator)
 
 ## Member Operator
-The member operator is _KubeSaw's data-plane_, is responsible for provisioning and managing the user namespaces and all the configuration inside those namespaces.
+The member operator is _KubeSaw's data-plane_, which is responsible for provisioning and managing the user namespaces and all the configurations inside those namespaces.
 
 There can be multiple member operators deployed as part of the same KubeSaw instance, ideally there should be a member operator per each cluster dedicated to the user workload (member cluster).
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -30,4 +30,6 @@ The proxy can help in the case of a multi-cluster solution with removing some of
 The source code for both registration-service and proxy is available here [registration-service](https://github.com/codeready-toolchain/registration-service)
 
 ## KSCTL
-ksctl is a command-line tool that helps you to manage your instance of KubeSaw service.
+ksctl is a command-line tool that helps you with managing your instance of KubeSaw.
+
+The source code is available here [ksctl](https://github.com/kubesaw/ksctl)

--- a/docs/components.md
+++ b/docs/components.md
@@ -3,7 +3,7 @@ This page provides a brief description of each KubeSaw component.
 
 ## Host Operator
 The host-operator is _KubeSaw's control-plane_, is responsible for managing the users, spaces, notifications and monitoring the kubesaw instance.
-One of the resources managed by host operator is the UserSignup resource, which is the source of truth for all user accounts. All other user-related resources are created from the UserSignup.
+One of the resources managed by host operator is the UserSignup resource, which is the source of truth for all user accounts. All the other user-related resources are created from the UserSignup.
 
 At the moment, only one host operator can be deployed per KubeSaw instance.
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -5,7 +5,7 @@ This page provides a brief description of each KubeSaw component.
 The host-operator is _KubeSaw's control-plane_, is responsible for managing the users, spaces, notifications and monitoring the kubesaw instance.
 One of the resources managed by host operator is the UserSignup resource, which is the source of truth for all user accounts. All other user-related resources are created from the UserSignup.
 
-At the moment, there can be only one host operator deployed per KubeSaw instance.
+At the moment, only one host operator can be deployed per KubeSaw instance.
 
 The source code is available here [host-operator](https://github.com/codeready-toolchain/host-operator)
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -1,0 +1,33 @@
+# Components
+This page provides a brief description of each KubeSaw component.
+
+## Host Operator
+The host-operator is _KubeSaw's control-plane_, is responsible for managing the users, spaces, notification and monitoring the kubesaw instance.
+One of the resources managed by host operator is the UserSignup resource, which is the source of truth for all user accounts. All other user-related resources are created from the UserSignup.
+
+At the moment, there can be only one host operator deployed per KubeSaw instance.
+
+The source code is available here [host-operator](https://github.com/codeready-toolchain/host-operator)
+
+## Member Operator
+The member operator is _KubeSaw's data-plane_, is responsible for provisioning and managing the user namespaces and all the configuration inside those namespaces.
+
+There can be multiple member-operator deployed per KubeSaw instance, ideally there would be a member operator per each member cluster.
+
+The source code is available here [member-operator](https://github.com/codeready-toolchain/member-operator)
+
+## Registration Service
+The Registration Service is a standalone web application that runs on the host cluster.  It provides a number of REST endpoints that the signup page can use to allow a user to sign up for a KubeSaw account. 
+The Registration Service application makes use of third party libraries such as Gin (an HTTP web framework) and Kubernetes client libraries (for interacting with the Kubernetes API) among others.
+
+### Proxy
+The Proxy is part of the registration-service application deployment, basically it's another set of REST endpoints implemented using the echo framework. It can be used in a multi-cluster environment to forward requests without the need to specify the cluster name, the proxy infers the target cluster from the user information and the target workspace/namespace of the request.
+
+Both Proxy and Registration-service are optional components and not required for having a fully functional KubeSaw instance.
+The registration service can be useful if your KubeSaw instance needs a signup mechanism/frontend.
+The proxy can help in the case of a multi-cluster solution with removing some of the _cluster awareness_ and friction for the end users or clients interacting with the instance.
+
+The source code for both registration-service and proxy is available here [registration-service](https://github.com/codeready-toolchain/registration-service)
+
+## KSCTL
+ksctl is a command-line tool that helps you to manage your instance of KubeSaw service.

--- a/docs/components.md
+++ b/docs/components.md
@@ -36,6 +36,6 @@ The proxy can help, in the case of a multi-cluster solution, with removing some 
 The source code for both registration-service and proxy is available here [registration-service](https://github.com/codeready-toolchain/registration-service)
 
 ## KSCTL
-ksctl is a command-line tool that helps you with managing your instance of KubeSaw.
+ksctl is a command-line tool that helps you manage your KubeSaw instance.
 
 The source code is available here [ksctl](https://github.com/kubesaw/ksctl)

--- a/docs/components.md
+++ b/docs/components.md
@@ -5,14 +5,12 @@ This page provides a brief description of each KubeSaw component.
 The host-operator is _KubeSaw's control-plane_, which is responsible for managing the users, spaces, notifications and monitoring the KubeSaw instance.
 One of the resources managed by host operator is the UserSignup resource, which is the source of truth for all user accounts. All the other user-related resources are created from the UserSignup.
 
-At the moment, only one host operator can be deployed per KubeSaw instance.
-
 The source code is available here [host-operator](https://github.com/codeready-toolchain/host-operator)
 
 ## Member Operator
 The member operator is _KubeSaw's data-plane_, which is responsible for provisioning and managing the user namespaces and all the configurations inside those namespaces.
 
-There can be multiple member operators deployed as part of the same KubeSaw instance, ideally there should be one member operator per each cluster, dedicated to the user workload (member cluster).
+There can be multiple member operators deployed as part of the same KubeSaw instance. Member operators are usually deployed per-cluster (member cluster) but can even co-exist in the same cluster.
 
 The source code is available here [member-operator](https://github.com/codeready-toolchain/member-operator)
 
@@ -24,8 +22,7 @@ The Registration Service application makes use of third party libraries such as 
 and Kubernetes client libraries (for interacting with the Kubernetes API) among others.
 
 ### Proxy
-The Proxy is part of the registration service application deployment,
-basically it's another set of REST endpoints implemented using the echo framework.
+The Proxy is part of the registration service application deployment.
 It can be used in a multi-cluster environment to forward requests without the need to specify the cluster context,
 the proxy infers the target cluster from the user information and the target workspace/namespace of the request.
 
@@ -36,6 +33,6 @@ The proxy can help, in the case of a multi-cluster solution, with removing some 
 The source code for both registration-service and proxy is available here [registration-service](https://github.com/codeready-toolchain/registration-service)
 
 ## KSCTL
-ksctl is a command-line tool that helps you manage your KubeSaw instance.
+ksctl is a command-line tool that helps you manage your KubeSaw instance. It provides commands for managing the clusters, spaces and users in KubeSaw.
 
 The source code is available here [ksctl](https://github.com/kubesaw/ksctl)

--- a/docs/components.md
+++ b/docs/components.md
@@ -2,7 +2,7 @@
 This page provides a brief description of each KubeSaw component.
 
 ## Host Operator
-The host-operator is _KubeSaw's control-plane_, is responsible for managing the users, spaces, notifications and monitoring the kubesaw instance.
+The host-operator is _KubeSaw's control-plane_, which is responsible for managing the users, spaces, notifications and monitoring the KubeSaw instance.
 One of the resources managed by host operator is the UserSignup resource, which is the source of truth for all user accounts. All the other user-related resources are created from the UserSignup.
 
 At the moment, only one host operator can be deployed per KubeSaw instance.


### PR DESCRIPTION
This PR adds a markdown file containing a brief description of each of the KubeSaw components.
It is just a starting , there will be more detailed explanations and architecture diagrams explaining the responsibilities of each component and how they interact.

Also for the ksctl we can move the Cheat sheet for commands here in the official document and have a link in the ksctl repo pointing to the docs.